### PR TITLE
test: reinforce 3A pattern (Arrange, Act, Assert)

### DIFF
--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -1,18 +1,23 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
-test('has title', async ({ page }) => {
-  await page.goto('https://playwright.dev/');
+test("has title", async ({ page }) => {
+  await page.goto("https://playwright.dev/");
 
   // Expect a title "to contain" a substring.
   await expect(page).toHaveTitle(/Playwright/);
 });
 
-test('get started link', async ({ page }) => {
-  await page.goto('https://playwright.dev/');
+test("get started link", async ({ page }) => {
+  // arrange
+  await page.goto("https://playwright.dev/");
 
+  // act
   // Click the get started link.
-  await page.getByRole('link', { name: 'Get started' }).click();
+  await page.getByRole("link", { name: "Get started" }).click();
 
+  // assert
   // Expects page to have a heading with the name of Installation.
-  await expect(page.getByRole('heading', { name: 'Installation' })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Installation" }),
+  ).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- Refines tests/example.spec.ts to better follow the 3A testing structure.
- Makes the test flow clearer by separating setup (Arrange), execution (Act), and verification (Assert).

## Why
- Improves readability and maintainability of Playwright tests.
- Encourages consistent test-writing style for future additions.

## Notes
- Focused change: test structure only.