### PR TITLE
test: update spec using "Record at cursor"

### DIFF
--- a/tests/First.spec.ts
+++ b/tests/First.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from "@playwright/test";
+
+test("Intro heading has correct text", async ({ page }) => {
+  await page.goto("https://playwright.dev/");
+
+  await page.getByRole("link", { name: "Docs" }).click();
+  const heading = page.getByRole("heading", {
+    name: "IntroductionDirect link to",
+  });
+
+  await expect(heading).toHaveText("Introduction");
+});


### PR DESCRIPTION
## Summary
- Add a Playwright test in tests/First.spec.ts
- Capture the test flow using Record at cursor

```ts
import { test, expect } from "@playwright/test";

test("Intro heading has correct text", async ({ page }) => {
  await page.goto("https://playwright.dev/");

  await page.getByRole("link", { name: "Docs" }).click();
  const heading = page.getByRole("heading", {
    name: "IntroductionDirect link to",
  });

  await expect(heading).toHaveText("Introduction");
});
```

## Validation
- Existing Playwright test run passed in VS Code Test Explorer