### PR TITLE
test(fixtures): add Playwright fixture usage examples

### DIFF
--- a/tests/Fixtures.spec.ts
+++ b/tests/Fixtures.spec.ts
@@ -1,0 +1,26 @@
+import { test, chromium } from "@playwright/test";
+
+test("Close cookies", async ({ page }) => {
+  await page.goto("https://www.lr.org/");
+  await page.getByRole("button", { name: "Allow selection" }).click();
+});
+
+test("Is the cookie banner still present?", async ({ page }) => {
+  await page.goto("https://www.lr.org/");
+  await page.pause();
+});
+
+test("Browser fixture", async ({ browser }) => {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  
+  await page.goto("https://www.lr.org/");
+});
+
+test("Create page manually", async () => {
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  await page.goto("https://www.lr.org/");
+});


### PR DESCRIPTION
## Summary
- add tests/Fixtures.spec.ts with fixture-focused Playwright examples
- cover cookie-banner interaction flow on https://www.lr.org/
- demonstrate both built-in browser fixture usage and manual chromium.launch() setup

## Changes
- new tests for cookie handling and page navigation
- example creating context/page from the browser fixture
- example creating browser/context/page manually

## Code
```ts
import { test, chromium } from "@playwright/test";

test("Close cookies", async ({ page }) => {
  await page.goto("https://www.lr.org/");
  await page.getByRole("button", { name: "Allow selection" }).click();
});

test("Is the cookie banner still present?", async ({ page }) => {
  await page.goto("https://www.lr.org/");
  await page.pause();
});

test("Browser fixture", async ({ browser }) => {
  const context = await browser.newContext();
  const page = await context.newPage();
  
  await page.goto("https://www.lr.org/");
});

test("Create page manually", async () => {
  const browser = await chromium.launch();
  const context = await browser.newContext();
  const page = await context.newPage();

  await page.goto("https://www.lr.org/");
});
```

## Notes
- scoped to fixture usage examples only
- no config or dependency changes